### PR TITLE
SEMI-1218

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remote-pay-cloud",
-  "version": "1.3.1-3",
+  "version": "1.3.1-4",
   "description": "Access Clover devices through the cloud.",
   "keywords": [
     "clover",

--- a/src/com/clover/remote/client/transport/websocket/CloverWebSocketClient.ts
+++ b/src/com/clover/remote/client/transport/websocket/CloverWebSocketClient.ts
@@ -42,9 +42,10 @@ export class CloverWebSocketClient implements WebSocketListener {
             this.socket.connect();
         } catch(e) {
             this.logger.error('connect, connectionError', e);
-            this.listener.connectionError(this);
+            this.listener.connectionError(this, e.message);
         }
     }
+
     public close(code?: number, reason?: string): void {
         this.socket.sendClose(code, reason);
     }
@@ -73,9 +74,17 @@ export class CloverWebSocketClient implements WebSocketListener {
         this.listener.onOpen(this);
     }
 
-    public onConnectError(websocket: CloverWebSocketInterface): void {
-        this.logger.error('onConnectError');
-        this.listener.connectionError(this);
+    /**
+     *
+     * @param {CloverWebSocketInterface} websocket
+     * @param event - A simple error event is passed per the websocket spec - https://www.w3.org/TR/websockets/#concept-websocket-close-fail
+     * It doesn't appear that an exact typing for the websocket error event is available, so I am using any.
+     */
+    public onConnectError(websocket: CloverWebSocketInterface, event: any): void {
+        let eventMessage: string = event.message || "Not available";
+        let message: string = `A websocket connection error has occurred.  Details: ${eventMessage}`;
+        this.logger.error(message);
+        this.listener.connectionError(this, message);
     }
 
     public onDisconnected(websocket: CloverWebSocketInterface): void {
@@ -87,6 +96,7 @@ export class CloverWebSocketClient implements WebSocketListener {
     }
 
     public onError(websocket: CloverWebSocketInterface): void {
+        this.logger.error('A websocket error has occurred.');
     }
 
     public onPingFrame(websocket: CloverWebSocketInterface): void {
@@ -94,10 +104,11 @@ export class CloverWebSocketClient implements WebSocketListener {
     }
 
     public onSendError(websocket: CloverWebSocketInterface): void  {
-        this.listener.onSendError("");//frame.getPayloadText());
+        this.listener.onSendError("");// frame.getPayloadText());
     }
 
     public onUnexpectedError(websocket: CloverWebSocketInterface): void {
+        this.logger.error('An unexpected websocket error has occurred.');
     }
 
     public send( message: string): void {

--- a/src/com/clover/remote/client/transport/websocket/CloverWebSocketClientListener.ts
+++ b/src/com/clover/remote/client/transport/websocket/CloverWebSocketClientListener.ts
@@ -14,7 +14,7 @@ export interface CloverWebSocketClientListener {
 
     onMessage(ws: CloverWebSocketClient, message: string);
 
-    connectionError(cloverNVWebSocketClient: CloverWebSocketClient);
+    connectionError(cloverNVWebSocketClient: CloverWebSocketClient, message?: string);
 
     onSendError(payloadText: string);
 }

--- a/src/com/clover/remote/client/transport/websocket/WebSocketCloverTransport.ts
+++ b/src/com/clover/remote/client/transport/websocket/WebSocketCloverTransport.ts
@@ -182,7 +182,7 @@ export abstract class WebSocketCloverTransport extends CloverTransport implement
 		this.clearWebsocket();
 	}
 
-	public connectionError(ws: CloverWebSocketClient, message?:string):void {
+	public connectionError(ws: CloverWebSocketClient, message?: string):void {
 		this.logger.debug('Not Responding...');
 
 		if (this.webSocket == ws) {
@@ -191,7 +191,6 @@ export abstract class WebSocketCloverTransport extends CloverTransport implement
 				observer.onDeviceDisconnected(this, message);
 			}
 		}
-		// this.reconnect();
 	}
 
 	public onNotResponding(ws: CloverWebSocketClient): void {

--- a/src/com/clover/remote/client/util/Logger.ts
+++ b/src/com/clover/remote/client/util/Logger.ts
@@ -31,7 +31,9 @@ export class Logger extends EventEmitter {
 		return log;
 
 		function toConsole() {
-			if (log.enabled || DebugConfig.loggingEnabled) {
+            var args = [].slice.call(arguments),
+				errorLog = args && args.length > 0 ? args[0] === "error" : false;
+			if (errorLog || log.enabled || DebugConfig.loggingEnabled) {
 				console.log.apply(console, arguments)
 			}
 		}

--- a/src/com/clover/websocket/WebSocketListener.ts
+++ b/src/com/clover/websocket/WebSocketListener.ts
@@ -1,6 +1,4 @@
-import {WebSocketState} from './WebSocketState';
 import { CloverWebSocketInterface } from './CloverWebSocketInterface';
-
 
 /**
  * Listener interface to receive WebSocket events.
@@ -23,9 +21,9 @@ export interface WebSocketListener {
 
     onConnected(websocket: CloverWebSocketInterface): void;
 
-    onConnectError(websocket: CloverWebSocketInterface): void;
+    onConnectError(websocket: CloverWebSocketInterface, errorEvent: any): void;
 
-    onDisconnected(websocket: CloverWebSocketInterface): void;
+    onDisconnected(websocket: CloverWebSocketInterface, errorEvent: any): void;
 
     onCloseFrame(websocket: CloverWebSocketInterface, closeCode: number, reason: string): void;
 
@@ -33,7 +31,7 @@ export interface WebSocketListener {
 
     onPingFrame(websocket: CloverWebSocketInterface): void;
 
-    onSendError(websocket: CloverWebSocketInterface): void;
+    onSendError(websocket: CloverWebSocketInterface, errorEvent: any): void;
 
-    onUnexpectedError(websocket: CloverWebSocketInterface): void;
+    onUnexpectedError(websocket: CloverWebSocketInterface, errorEvent: any): void;
 }


### PR DESCRIPTION
-  Pass web socket errors through to the listener.  Previously, only the client was being passed.  Modified the code to pass the simple error event as well.
- Modified logger to always log error messages to the console.
- Added error checking to CloverWebSocketInterface that warns users if their websocket implementation is not compatible with our API.
- Minor cleanup.