### PR TITLE
Instantiate new XMLHttpRequest per request, remove state and getRespo…

### DIFF
--- a/src/com/clover/remote/client/transport/websocket/WebSocketCloudCloverTransport.ts
+++ b/src/com/clover/remote/client/transport/websocket/WebSocketCloudCloverTransport.ts
@@ -143,8 +143,8 @@ export class WebSocketCloudCloverTransport extends WebSocketCloverTransport {
             httpUrl = deviceWebSocketEndpointCopy.replace("ws", "http");
         }
         this.httpSupport.options(httpUrl,
-            () => this.afterOptionsCall(deviceWebSocketEndpoint),
-            () => this.afterOptionsCall(deviceWebSocketEndpoint));
+            (data, xmlHttpReqImpl) => this.afterOptionsCall(deviceWebSocketEndpoint, xmlHttpReqImpl),
+            (data, xmlHttpReqImpl) => this.afterOptionsCall(deviceWebSocketEndpoint, xmlHttpReqImpl));
     }
 
     /**
@@ -155,10 +155,13 @@ export class WebSocketCloudCloverTransport extends WebSocketCloverTransport {
      *
      * @param deviceWebSocketEndpoint
      */
-    private afterOptionsCall(deviceWebSocketEndpoint:string): void {
+    private afterOptionsCall(deviceWebSocketEndpoint: string, xmlHttpReqImpl: any): void {
         // See com.clover.support.handler.remote_pay.RemotePayConnectionControlHandler#X_CLOVER_CONNECTED_ID
         // This checks for an existing connection, which includes the id of the terminal that is connected.
-        var connectedId = this.httpSupport.getResponseHeader(WebSocketCloudCloverTransport.X_CLOVER_CONNECTED_ID);
+        let connectedId = "";
+        if (xmlHttpReqImpl && typeof xmlHttpReqImpl["getResponseHeader"] === "function") {
+            connectedId = xmlHttpReqImpl.getResponseHeader(WebSocketCloudCloverTransport.X_CLOVER_CONNECTED_ID)
+        }
         if (connectedId && !this.forceConnect) {
             if (this.friendlyId == connectedId) {
                 // Do anything here?  This is already connected.

--- a/src/com/clover/util/HttpSupport.ts
+++ b/src/com/clover/util/HttpSupport.ts
@@ -22,14 +22,8 @@ export class HttpSupport {
      */
     xmlHttpImplClass: any;
 
-    /**
-     * The instance of the call interface
-     */
-    xmlHttp: any;
-
     public constructor(xmlHttpImplClass:any) {
         this.xmlHttpImplClass = xmlHttpImplClass;
-        this.xmlHttp = new this.xmlHttpImplClass();
     }
 
     private setXmlHttpCallback(xmlHttpInst:any, endpoint:string, onDataLoaded:Function, onError:Function):void {
@@ -42,7 +36,7 @@ export class HttpSupport {
                             if (xmlHttpInst.responseText && xmlHttpInst.responseText != "") {
                                 data = JSON.parse(xmlHttpInst.responseText);
                             }
-                            onDataLoaded(data);
+                            onDataLoaded(data, xmlHttpInst);
                         }
                     } catch (e) {
                         this.logger.error(endpoint, e);
@@ -61,43 +55,41 @@ export class HttpSupport {
         }.bind(this);
     }
 
-    public getResponseHeader(headerName:string): string {
-        return this.xmlHttp.getResponseHeader(headerName);
-    }
-
     /**
      * Make the REST call to get the data
      */
     public doXmlHttp(method:string, endpoint:string, onDataLoaded:Function, onError:Function):void {
-        this.setXmlHttpCallback(this.xmlHttp, endpoint, onDataLoaded, onError);
-        this.xmlHttp.open(method, endpoint, true);
+        const xmlHttp = new this.xmlHttpImplClass();
+        this.setXmlHttpCallback(xmlHttp, endpoint, onDataLoaded, onError);
+        xmlHttp.open(method, endpoint, true);
         // Handle the following Firefox bug - https://bugzilla.mozilla.org/show_bug.cgi?id=433859#c4
         // This check can only be performed in a browser environment so make sure navigator is defined first.
         if (typeof(navigator) !== "undefined" && navigator.userAgent.search("Firefox")) {
-            this.xmlHttp.setRequestHeader("Accept", "*/*");
+            xmlHttp.setRequestHeader("Accept", "*/*");
         }
 
-        this.xmlHttp.send();
+        xmlHttp.send();
     }
 
     public doXmlHttpSendJson(method:string, sendData:any, endpoint:string, onDataLoaded:Function, onError:Function, additionalHeaders?:any):void {
-        this.setXmlHttpCallback(this.xmlHttp, endpoint, onDataLoaded, onError);
+        const xmlHttp = new this.xmlHttpImplClass();
+        this.setXmlHttpCallback(xmlHttp, endpoint, onDataLoaded, onError);
 
-        this.xmlHttp.open(method, endpoint, true);
+        xmlHttp.open(method, endpoint, true);
         if (additionalHeaders) {
             for (var key in additionalHeaders) {
                 if (additionalHeaders.hasOwnProperty(key)) {
-                    this.xmlHttp.setRequestHeader(key, additionalHeaders[key]);
+                    xmlHttp.setRequestHeader(key, additionalHeaders[key]);
                 }
             }
         }
         if (sendData) {
-            this.xmlHttp.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+            xmlHttp.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
             var sendDataStr = JSON.stringify(sendData);
-            this.xmlHttp.send(sendDataStr);
+            xmlHttp.send(sendDataStr);
         }
         else {
-            this.xmlHttp.send();
+            xmlHttp.send();
         }
     }
     /**


### PR DESCRIPTION
- After a bit of investigation it appears that re-using the same XMLHttpRequest object across requests may not be the best/standard practice (https://stackoverflow.com/questions/11502244/reuse-xmlhttprequest-object-or-create-a-new-one).  Creating a new XMLHttpRequest object per request removes the need for the fork of and PR against - https://www.npmjs.com/package/xmlhttprequest-ssl.
- Possible breaking API change, removal of public API HttpSupport.getResponseHeader.  This call can no longer be supported as there is no xmlHttpRequest state on HttpSupport.  
- Callbacks can obtain the headers via the xmlHttpRequest passed as a second parameter (data, xmlHttpRequest).
