### PR TITLE
SEMI-1352, SEMI-1332, General Improvements

### DIFF
--- a/src/com/clover/remote/client/CloverConnector.ts
+++ b/src/com/clover/remote/client/CloverConnector.ts
@@ -174,10 +174,12 @@ export class CloverConnector implements sdk.remotepay.ICloverConnector {
             transactionSettings.setAutoAcceptPaymentConfirmations(request.getAutoAcceptPaymentConfirmations());
             transactionSettings.setAutoAcceptSignature(request.getAutoAcceptSignature());
 
+            let paymentRequestType = null;
             if (request instanceof sdk.remotepay.PreAuthRequest) {
-                // nothing extra as of now
+                paymentRequestType = CloverConnector.TxTypeRequestInfo.PREAUTH_REQUEST;
             }
             else if (request instanceof sdk.remotepay.AuthRequest) {
+                paymentRequestType = CloverConnector.TxTypeRequestInfo.AUTH_REQUEST;
                 let req: sdk.remotepay.AuthRequest = request;
                 if (req.getTaxAmount()) {
                     builder.setTaxAmount(req.getTaxAmount());
@@ -198,6 +200,7 @@ export class CloverConnector implements sdk.remotepay.ICloverConnector {
                 transactionSettings.setTipMode(sdk.payments.TipMode.ON_PAPER); // overriding TipMode, since it's an Auth request
             }
             else if (request instanceof sdk.remotepay.SaleRequest) {
+                paymentRequestType = CloverConnector.TxTypeRequestInfo.SALE_REQUEST;
                 let req: sdk.remotepay.SaleRequest = request;
                 // shared with AuthRequest
                 if (req.getAllowOfflinePayment()) {
@@ -226,7 +229,7 @@ export class CloverConnector implements sdk.remotepay.ICloverConnector {
 
             builder.setTransactionSettings(transactionSettings);
             let payIntent: sdk.remotemessage.PayIntent = builder.build();
-            this.device.doTxStart(payIntent, null); //
+            this.device.doTxStart(payIntent, null, paymentRequestType);
         }
     }
 
@@ -574,7 +577,7 @@ export class CloverConnector implements sdk.remotepay.ICloverConnector {
             builder.setTransactionSettings(transactionSettings);
 
             let payIntent: sdk.remotepay.PayIntent = builder.build();
-            this.device.doTxStart(payIntent, null);
+            this.device.doTxStart(payIntent, null, CloverConnector.TxTypeRequestInfo.CREDIT_REQUEST);
         }
     }
 

--- a/src/com/clover/remote/client/device/CloverDevice.ts
+++ b/src/com/clover/remote/client/device/CloverDevice.ts
@@ -61,8 +61,9 @@ export abstract class CloverDevice {
      *
      * @param {sdk.remotemessage.PayIntent} payIntent
      * @param {sdk.order.Order} order
+     * @param {string} requestInfo - request type.
      */
-    public abstract doTxStart(payIntent: sdk.remotemessage.PayIntent, order: sdk.order.Order): void;
+    public abstract doTxStart(payIntent: sdk.remotemessage.PayIntent, order: sdk.order.Order, requestInfo: string): void;
 
     /**
      * Key Press

--- a/src/com/clover/remote/client/transport/websocket/CloverWebSocketClient.ts
+++ b/src/com/clover/remote/client/transport/websocket/CloverWebSocketClient.ts
@@ -30,6 +30,10 @@ export class CloverWebSocketClient implements WebSocketListener {
         return (this.socket) ? this.socket.getReadyState() : null;
     }
 
+    public getBufferedAmount(): number {
+        return (this.socket ? this.socket.getBufferedAmount(): 0);
+    }
+
     public connect(): void {
         if (this.socket != null) {
             throw new Error("Socket already created. Must create a new CloverWebSocketClient");

--- a/src/com/clover/util/IImageUtil.ts
+++ b/src/com/clover/util/IImageUtil.ts
@@ -12,4 +12,14 @@ export interface IImageUtil {
      * @returns {string} a base 64 encoded string of the image.
      */
     getBase64Image(img: any): string;
+
+    /**
+     * Loads an image from a URL.
+     *
+     * @param {string} url
+     * @param {(Image) => {}} onLoad
+     * @param {(any) => {}} onError
+     */
+    loadImageFromURL(url: string,  onLoad: (image: any) => void, onError: (errorMessage: string) => void): void;
+
 }

--- a/src/com/clover/util/ImageUtil.ts
+++ b/src/com/clover/util/ImageUtil.ts
@@ -12,8 +12,8 @@ export class ImageUtil implements IImageUtil {
     public getBase64Image(img: HTMLImageElement): string {
         // Create an empty canvas element
         var canvas = document.createElement("canvas");
-        canvas.width = img.width;
-        canvas.height = img.height;
+        canvas.width = img.naturalWidth;
+        canvas.height = img.naturalHeight;
 
         // Copy the image contents to the canvas
         var ctx = canvas.getContext("2d");
@@ -27,4 +27,29 @@ export class ImageUtil implements IImageUtil {
 
         return dataURL.replace(/^data:image\/(png|jpg);base64,/, "");
     }
+
+    public loadImageFromURL(url: string, onLoad: (image: any) => void, onError: (errorMessage: string) => void) {
+        const image = new Image();
+        const imageLoadHandler = () => {
+            if (onLoad) {
+                onLoad(image);
+            }
+            clearEventListeners();
+        };
+        const imageErrorHandler = () => {
+            if (onError) {
+                onError(`An Image could not be loaded. Please check that the URL (${url}) is accessible.`);
+            }
+            clearEventListeners();
+        };
+        const clearEventListeners = () => {
+            image.removeEventListener("load", imageLoadHandler);
+            image.removeEventListener("error", imageErrorHandler);
+        }
+        image.addEventListener("load", imageLoadHandler);
+        image.addEventListener("error", imageErrorHandler);
+        image.crossOrigin = "Anonymous";
+        image.src = url;
+    }
+
 }


### PR DESCRIPTION
SEMI-1332 - Set requestInfo.
SEMI-1352 - Issue printing large images from URLs.  The images are now retrieved on the front-end so the chunking API can be used.  The ImageUtils interface has been appended to, to account for Node applications in the future. 
Improvements:
- Cleared up version defaults.  Added helper methods to detect features vs. manually checking version numbers in the code.
- Modify WebSocketClover transport to use an interval (instead of timeout) and check the bufferedAmount on the WS before sending new messages.



