### PR TITLE
SEMI-1495

### DIFF
--- a/src/com/clover/remote/client/transport/websocket/WebSocketCloudCloverTransport.ts
+++ b/src/com/clover/remote/client/transport/websocket/WebSocketCloudCloverTransport.ts
@@ -91,7 +91,7 @@ export class WebSocketCloudCloverTransport extends WebSocketCloverTransport {
         this.httpSupport.postData(alertEndpoint,
             (data) => this.deviceNotificationSent(data),
             (error) => {
-                this.connectionError(this.webSocket, `Error sending alert to device. Details: ${error.message}`);
+                this.connectionError(this.cloverWebSocketClient, `Error sending alert to device. Details: ${error.message}`);
                 // This may end a reconnect attempt
                 this.setReconnecting(false);
             },
@@ -116,7 +116,7 @@ export class WebSocketCloudCloverTransport extends WebSocketCloverTransport {
                 notificationResponse.host, notificationResponse.token, this.friendlyId, this.forceConnect);
             this.doOptionsCallToAvoid401Error(deviceWebSocketEndpoint);
         } else {
-            this.connectionError(this.webSocket, "Could not send alert to device.");
+            this.connectionError(this.cloverWebSocketClient, "Could not send alert to device.");
             // This may end a reconnect attempt
             this.setReconnecting(false);
         }
@@ -166,17 +166,17 @@ export class WebSocketCloudCloverTransport extends WebSocketCloverTransport {
             if (this.friendlyId == connectedId) {
                 // Do anything here?  This is already connected.
                 this.logger.debug("Trying to connect, but already connected to friendlyId '" + this.friendlyId + "'");
-                if (this.webSocket) {
-                    this.webSocket.close();
+                if (this.cloverWebSocketClient) {
+                    this.cloverWebSocketClient.close();
                 }
             } else {
-                this.connectionError(this.webSocket, "Device is already connected to '" + this.friendlyId + "'");
+                this.connectionError(this.cloverWebSocketClient, "Device is already connected to '" + this.friendlyId + "'");
                 // This may end a reconnect attempt
                 this.setReconnecting(false);
                 return; // done connecting
             }
             // If the device socket is already connected and good, just return.
-            if (this.webSocket && this.webSocket.getWebSocketState() == WebSocketState.OPEN) {
+            if (this.cloverWebSocketClient && this.cloverWebSocketClient.getWebSocketState() == WebSocketState.OPEN) {
                 // This may end a reconnect attempt
                 this.setReconnecting(false);
                 return; // done connecting
@@ -191,7 +191,7 @@ export class WebSocketCloudCloverTransport extends WebSocketCloverTransport {
      * @param ws
      */
     public onOpen(ws: CloverWebSocketClient): void {
-        if (this.webSocket == ws) {
+        if (this.cloverWebSocketClient == ws) {
             super.onOpen(ws);
             this.notifyDeviceReady();
         }

--- a/src/com/clover/remote/client/transport/websocket/WebSocketPairedCloverTransport.ts
+++ b/src/com/clover/remote/client/transport/websocket/WebSocketPairedCloverTransport.ts
@@ -47,7 +47,7 @@ export class WebSocketPairedCloverTransport extends WebSocketCloverTransport {
      * @param ws
      */
     public onOpen(ws: CloverWebSocketClient): void {
-        if (this.webSocket == ws) {
+        if (this.cloverWebSocketClient == ws) {
             super.onOpen(ws);
             this.sendPairRequest();
         }
@@ -71,7 +71,7 @@ export class WebSocketPairedCloverTransport extends WebSocketCloverTransport {
      * @param message
      */
     public onMessage_cwscl(ws: CloverWebSocketClient, message: string): void { // CloverWebSocketClientListener
-        if (this.webSocket == ws) {
+        if (this.cloverWebSocketClient == ws) {
             if (this.isPairing) {
                 let remoteMessage: sdk.remotemessage.RemoteMessage = this.messageParser.parseToRemoteMessage(message);
                 var sdkMessage: sdk.remotemessage.Message = this.messageParser.parseMessageFromRemoteMessageObj(remoteMessage);
@@ -116,5 +116,9 @@ export class WebSocketPairedCloverTransport extends WebSocketCloverTransport {
 
     public setPairingDeviceConfiguration(pairingDeviceConfiguration: PairingDeviceConfiguration): void {
         this.pairingDeviceConfiguration = pairingDeviceConfiguration;
+    }
+
+    public setAuthToken(authToken: string) {
+        this.authToken = authToken;
     }
 }

--- a/src/com/clover/websocket/CloverWebSocketInterface.ts
+++ b/src/com/clover/websocket/CloverWebSocketInterface.ts
@@ -117,7 +117,16 @@ export abstract class CloverWebSocketInterface {
 
     public sendClose(code?: number, reason?: string): CloverWebSocketInterface {
         this.logger.debug("Close sent code ", code, " reason ", reason);
-        this.webSocket.close(code, reason);
+        try {
+            /** 1000 indicates normal closure.  To avoid InvalidAccessErrors if no code is available default to 1000.
+             *  Per the websocket spec:
+             *    "If the method's first argument is present but is not an integer equal to 1000 or in the range 3000 to 4999,
+             *     throw an InvalidAccessError exception and abort these steps."
+             */
+            this.webSocket.close(code || 1000, reason || "NORMAL_CLOSURE");
+        } catch (e) {
+            this.logger.error('error disposing of transport.', e);
+        }
         return this;
     }
 


### PR DESCRIPTION
- Rename webSocket to cloverWebSocketClient to clarify what we are dealing with.  The name webSocket implied that we were dealing with the native webSocket but we were really dealing with a CloverWebSocketClient.
- Modify the sendClose function in CloverWebSocketInterface.ts to pass a default code and message if the code and message are undefined/null.