### PR TITLE
Links to SNPD updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If used from a browser, the browser must support WebSockets. For more informatio
 
 Please see the [Getting started with Clover Connector tutorial for JavaScript](https://docs.clover.com/build/getting-started-with-cloverconnector/?sdk=browser).
 
-Install your choice of pay display app on the Clover device:
+As a good starting point, install your choice of pay display app on the Clover device:
 - Cloud Pay Display app for cloud-based interactions between your POS system and the Clover device
 - [Secure Network Pay Display app](https://docs.clover.com/build/secure-network-pay-display/) for wireless local network-based interactions between your POS system and the Clover device
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ If used from a browser, the browser must support WebSockets. For more informatio
 
 ## Getting Started
 
-Please see the [Getting started with Clover Connector tutorial for JavaScript](https://docs.clover.com/build/getting-started-with-clover-connector/?sdk=browser). 
+Please see the [Getting started with Clover Connector tutorial for JavaScript](https://docs.clover.com/build/getting-started-with-cloverconnector/?sdk=browser).
+
+Install your choice of pay display app on the Clover device:
+- Cloud Pay Display app for cloud-based interactions between your POS system and the Clover device
+- [Secure Network Pay Display app](https://docs.clover.com/build/secure-network-pay-display/) for wireless local network-based interactions between your POS system and the Clover device
 
 ### Examples
 Example applications can be found on [GitHub](https://github.com/clover/remote-pay-cloud-examples).
@@ -37,6 +41,7 @@ Example applications can be found on [GitHub](https://github.com/clover/remote-p
 ### Additional resources
 - [Online Docs](http://clover.github.io/remote-pay-cloud/1.4.3/)
 - [Release Notes](https://github.com/clover/remote-pay-cloud/releases)
+- [Secure Network Pay Display](https://docs.clover.com/build/secure-network-pay-display/)
 - [Tutorial for the Browser SDK](https://docs.clover.com/build/getting-started-with-cloverconnector/?sdk=browser)
 - [API Class Documentation](http://clover.github.io/remote-pay-cloud-api/1.4.2/)
 - [Clover Developer Community](https://community.clover.com/index.html)


### PR DESCRIPTION
A new article has been created for Secure Network Pay: https://docs.clover.com/build/secure-network-pay-display/. New information is added to the Getting Started section for the supported pay display apps. The Additional resources section has been updated with SNPD as a resource. In addition, existing links to the Browser SDK tutorial are updated to navigate to the correct location in docs.clover.com.