### PR TITLE
WebSocketCloudCloverDeviceConfigurationBuilder type update

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,3 @@
-// Definitions by: David <https://github.com/david-clover-com>
-//                 Trevor <https://github.com/redharp>
-
 export {Logger} from "../src/com/clover/remote/client/util/Logger";
 export {DebugConfig} from "../src/com/clover/remote/client/util/DebugConfig";
 export {HttpSupport} from "../src/com/clover/util/HttpSupport";

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,6 @@
+// Definitions by: David <https://github.com/david-clover-com>
+//                 Trevor <https://github.com/redharp>
+
 export {Logger} from "../src/com/clover/remote/client/util/Logger";
 export {DebugConfig} from "../src/com/clover/remote/client/util/DebugConfig";
 export {HttpSupport} from "../src/com/clover/util/HttpSupport";
@@ -9,7 +12,7 @@ export {CloverDeviceConfiguration} from "../src/com/clover/remote/client/device/
 
 export {WebSocketCloverDeviceConfiguration} from "../src/com/clover/remote/client/device/WebSocketCloverDeviceConfiguration";
 export {WebSocketPairedCloverDeviceConfiguration} from "../src/com/clover/remote/client/device/WebSocketPairedCloverDeviceConfiguration";
-export {WebSocketCloudCloverDeviceConfiguration} from "../src/com/clover/remote/client/device/WebSocketCloudCloverDeviceConfiguration";
+export {WebSocketCloudCloverDeviceConfiguration, WebSocketCloudCloverDeviceConfigurationBuilder} from "../src/com/clover/remote/client/device/WebSocketCloudCloverDeviceConfiguration";
 
 export {CloverTransport} from "../src/com/clover/remote/client/transport/CloverTransport";
 export {CloverTransportObserver} from "../src/com/clover/remote/client/transport/CloverTransportObserver";


### PR DESCRIPTION
Hello Clover, ran into a small issue while testing with types when following the remote-pay cloud documentation.

**Change**:
* Add `WebSocketCloudCloverDeviceConfigurationBuilder` to types
  * The documentation shows the builder being used but anyone using typescript will get an error unless manually updating the provided `*.d.ts` from the SDK by hand.  I see that `@types` was giving problems evidenced by the last commit message, or else I would make a PR there.


Thanks~~
